### PR TITLE
Fixing .replace is not a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ async function main() {
       core.setOutput(`id`, `${workItem.id}`);
     }
   } catch (error) {
-    core.setFailed(error);
+    core.setFailed(error.toString());
   }
 }
 
@@ -237,7 +237,7 @@ async function create(vm) {
     console.log("Error: creatWorkItem failed");
     console.log(patchDocument);
     console.log(error);
-    core.setFailed(error);
+    core.setFailed(error.toString());
   }
 
   return workItemSaveResult;
@@ -423,7 +423,7 @@ async function find(vm) {
     console.log(
       "Error: Connecting to organization. Check the spelling of the organization name and ensure your token is scoped correctly."
     );
-    core.setFailed(error);
+    core.setFailed(error.toString());
     return -1;
   }
 
@@ -450,7 +450,7 @@ async function find(vm) {
   } catch (error) {
     console.log("Error: queryByWiql failure");
     console.log(error);
-    core.setFailed(error);
+    core.setFailed(error.toString());
     return -1;
   }
 
@@ -462,7 +462,7 @@ async function find(vm) {
       return result;
     } catch (error) {
       console.log("Error: getWorkItem failure");
-      core.setFailed(error);
+      core.setFailed(error.toString());
       return -1;
     }
   } else {


### PR DESCRIPTION
## Problem

Eventually the Action _Issues to Work Items_ will fail with the following error:

```
Set values from payload & env
[14](https://github.com/microsoft/SynapseML/runs/5159806508?check_suite_focus=true#step:2:14)
Check to see if work item already exists
[15](https://github.com/microsoft/SynapseML/runs/5159806508?check_suite_focus=true#step:2:15)
No work item found, creating work item from issue
[16](https://github.com/microsoft/SynapseML/runs/5159806508?check_suite_focus=true#step:2:16)
(node:1486) UnhandledPromiseRejectionWarning: TypeError: (s || "").replace is not a function
[17](https://github.com/microsoft/SynapseML/runs/5159806508?check_suite_focus=true#step:2:17)
at escapeData (/home/runner/work/_actions/mhamilton723/github-actions-issue-to-work-item/master/node_modules/@actions/core/lib/command.js:66:10)
[18](https://github.com/microsoft/SynapseML/runs/5159806508?check_suite_focus=true#step:2:18)
at Command.toString (/home/runner/work/_actions/mhamilton723/github-actions-issue-to-work-item/master/node_modules/@actions/core/lib/command.js:60:35)
[19](https://github.com/microsoft/SynapseML/runs/5159806508?check_suite_focus=true#step:2:19)
at issueCommand (/home/runner/work/_actions/mhamilton723/github-actions-issue-to-work-item/master/node_modules/@actions/core/lib/command.js:23:30)
[20](https://github.com/microsoft/SynapseML/runs/5159806508?check_suite_focus=true#step:2:20)
at Object.issue (/home/runner/work/_actions/mhamilton723/github-actions-issue-to-work-item/master/node_modules/@actions/core/lib/command.js:27:5)
[21](https://github.com/microsoft/SynapseML/runs/5159806508?check_suite_focus=true#step:2:21)
at error (/home/runner/work/_actions/mhamilton723/github-actions-issue-to-work-item/master/node_modules/@actions/core/lib/core.js:127:15)
[22](https://github.com/microsoft/SynapseML/runs/5159806508?check_suite_focus=true#step:2:22)
at Object.setFailed (/home/runner/work/_actions/mhamilton7[23](https://github.com/microsoft/SynapseML/runs/5159806508?check_suite_focus=true#step:2:23)/github-actions-issue-to-work-item/master/node_modules/@actions/core/lib/core.js:101:5)
23
at main (/home/runner/work/_actions/mhamilton723/github-actions-issue-to-work-item/master/index.js:116:10)
[24](https://github.com/microsoft/SynapseML/runs/5159806508?check_suite_focus=true#step:2:24)
at processTicksAndRejections (internal/process/task_queues.js:93:5)
[25](https://github.com/microsoft/SynapseML/runs/5159806508?check_suite_focus=true#step:2:25)
(node:1486) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
[26](https://github.com/microsoft/SynapseML/runs/5159806508?check_suite_focus=true#step:2:26)
(node:1486) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

It usually passes if you rerun the failed Action.

## Solution

It looks like it is a [known issue](https://github.com/actions/toolkit/issues/398). According to the best solution in it, we need to always pass a string to `setFailed(string param)` and we were not always doing that. This PR is about fixing it.